### PR TITLE
src: hexUtils.c: Fix build with -Wwrite-strings

### DIFF
--- a/src/hexUtils.c
+++ b/src/hexUtils.c
@@ -83,7 +83,7 @@ void test_hex_nibble_parsing() {
 
 void test_hex_parsing() {
     struct {
-        char* hex;
+        const char* hex;
         uint8_t raw;
     } testVectors[] = {
         {"ff", 0xff},


### PR DESCRIPTION
Note that this is code is only used for unit tests but it is always built.